### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cucats/website/security/code-scanning/2](https://github.com/cucats/website/security/code-scanning/2)

To fix the issue, add a `permissions` block specifying the minimum set of permissions required—ideally at the workflow root, to apply it to all jobs by default. For this workflow, since only source code is being read and no modifications to the repository (like creating releases, pushing changes, etc.) are being done, the minimal necessary permission is `contents: read`. This should be inserted just below the workflow name and above the `on:` block (typically after line 1). No changes are required within the jobs or steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
